### PR TITLE
updated builtin functions

### DIFF
--- a/docs/rn/0.0.18.md
+++ b/docs/rn/0.0.18.md
@@ -1,0 +1,7 @@
+# Release 0.0.18
+
+[ChangeLog](https://github.com/kform-dev/choreo/releases)
+
+## renamed the starlark builtin commands using the python convention
+
+change isIPv4 and isIPv6 to is_ipv4 and is_ipv6

--- a/pkg/controller/reconciler/starlark/reconciler.go
+++ b/pkg/controller/reconciler/starlark/reconciler.go
@@ -70,8 +70,8 @@ func NewReconcilerFn(client resourceclient.Client, reconcileConfig *choreov1alph
 			"get_prefixlength":     starlark.NewBuiltin("get_prefixlength", getPrefixLength),
 			"get_subnetname":       starlark.NewBuiltin("get_subnetname", getSubnetName),
 			"get_address":          starlark.NewBuiltin("get_address", getAddress),
-			"isIPv4":               starlark.NewBuiltin("isIPv4", isIPv4),
-			"isIPv6":               starlark.NewBuiltin("isIPv6", isIPv6),
+			"is_ipv4":              starlark.NewBuiltin("is_ipv4", isIPv4),
+			"is_ipv6":              starlark.NewBuiltin("is_ipv6", isIPv6),
 			"is_conditionready":    starlark.NewBuiltin("is_condition_ready", isConditionReady),
 		}
 


### PR DESCRIPTION
renamed builtin functions using the python convention with _ isIPv6 -> is_ipv6, same for isIPv4