### PR TITLE
Improvements on Git integration: private repositories and non-standard main branch

### DIFF
--- a/pkg/repository/git/git.go
+++ b/pkg/repository/git/git.go
@@ -28,6 +28,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/henderiw/logger/log"
 )
 
@@ -179,16 +180,19 @@ func fetchAll(ctx context.Context, repo *git.Repository) error {
 		},
 		Tags: git.AllTags,
 	}
-	err := repo.Fetch(fetchOptions)
-	if err != nil {
-		if err == git.NoErrAlreadyUpToDate {
-			log.Debug("Repository already up-to-date")
-			return nil
+	return doGitWithAuth(ctx, func(auth transport.AuthMethod) error {
+		fetchOptions.Auth = auth
+		err := repo.Fetch(fetchOptions)
+		if err != nil {
+			if err == git.NoErrAlreadyUpToDate {
+				log.Debug("Repository already up-to-date")
+				return nil
+			}
+			log.Error("Failed to fetch updates", "error", err)
+			return fmt.Errorf("failed to fetch updates: %v", err)
 		}
-		log.Error("Failed to fetch updates", "error", err)
-		return fmt.Errorf("failed to fetch updates: %v", err)
-	}
-	return nil
+		return nil
+	})
 }
 
 func resetToRemoteHead(ctx context.Context, repo *git.Repository, branch plumbing.ReferenceName) error {
@@ -334,6 +338,16 @@ func doGitWithAuth(ctx context.Context, op func(transport.AuthMethod) error) err
 // getAuthMethod fetches the credentials for authenticating to git. It caches the
 // credentials between calls and refresh credentials when the tokens have expired.
 func getAuthMethod(_ context.Context, _ bool) (transport.AuthMethod, error) {
+	username := os.Getenv("GIT_USERNAME")
+	password := os.Getenv("GIT_PASSWORD")
+
+	if username != "" && password != "" {
+		return &http.BasicAuth{
+			Username: username,
+			Password: password,
+		}, nil
+	}
+	
 	// If no secret is provided, we try without any auth.
 	return nil, nil
 }

--- a/pkg/repository/git/refs.go
+++ b/pkg/repository/git/refs.go
@@ -17,13 +17,14 @@ limitations under the License.
 package git
 
 import (
+	"os"
+
 	"github.com/go-git/go-git/v5/plumbing"
 )
 
 const (
 	//DefaultMainReferenceName plumbing.ReferenceName = "refs/heads/main"
 	OriginName string     = "origin"
-	MainBranch BranchName = "main"
 
 	BranchPrefixInRemoteRepo = "refs/remotes/" + OriginName + "/"
 	BranchPrefixInLocalRepo  = "refs/heads/"
@@ -52,6 +53,8 @@ var (
 			config.RefSpec(tagsPrefixInLocalRepo + "*:" + tagsPrefixInRemoteRepo + "*"),
 		}
 	*/
+	
+	MainBranch BranchName = BranchName(os.Getenv("GIT_MAIN_BRANCH"))
 )
 
 // BranchName represents a relative branch name (i.e. 'main', 'drafts/bucket/v1')

--- a/pkg/repository/repogit/repo.go
+++ b/pkg/repository/repogit/repo.go
@@ -646,8 +646,8 @@ func (r *repo) PushBranch(branch string) error {
 			config.RefSpec("+" + lgit.BranchName(branch).BranchInRemote() + "*:" + lgit.BranchName(branch).BranchInLocal() + "*"),
 		},
 		Auth: &http.BasicAuth{
-			Username: "henderiw",
-			Password: "your-access-token",
+			Username: os.Getenv("GIT_USERNAME"),
+			Password: os.Getenv("GIT_PASSWORD"),
 		},
 	})
 }


### PR DESCRIPTION
This PR adds the possibility to exec the package in a context in which the target git repository is private.
It can be managed setting the environment variables `GIT_USERNAME` and `GIT_PASSWORD`.
If these variables are not given, it tries to do without authentication (only for the operations admitted, while the credentials are required in case of push)

It adds also the possibility to use repos in which the principal branch is not `main`, using the environment variable `GIT_MAIN_BRANCH`.